### PR TITLE
Permitir acceso público a GET /api/products y proteger POST/PUT/DELET…

### DIFF
--- a/src/main/java/accounttransaction/configuration/security/SecurityConfig.java
+++ b/src/main/java/accounttransaction/configuration/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package accounttransaction.configuration.security;
 import accounttransaction.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -24,20 +25,28 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/actuator/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/api/users/register",
-                                "/api/users/login"
-                        ).permitAll()
-                        .requestMatchers("/api/products/**").authenticated()
-                        .anyRequest().permitAll()
-                );
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/actuator/**",
+                    "/v3/api-docs/**",
+                    "/swagger-ui/**",
+                    "/swagger-ui.html",
+                    "/api/users/register",
+                    "/api/users/login"
+                ).permitAll()
+
+                // Permitir solo GET públicos en productos
+                .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
+
+                // Proteger POST, PUT, DELETE en productos
+                .requestMatchers(HttpMethod.POST, "/api/products/**").authenticated()
+                .requestMatchers(HttpMethod.PUT, "/api/products/**").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/api/products/**").authenticated()
+
+                .anyRequest().permitAll()
+            );
 
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();


### PR DESCRIPTION
Se ajustó la configuración de seguridad para permitir acceso público a los endpoints  y , manteniendo la protección con JWT para operaciones sensibles (, , ). Esto mejora la experiencia de usuarios no autenticados que necesitan consultar productos, sin comprometer la integridad de los datos.
Cambios realizados:
• 	Se agregó distinción por método HTTP en 
• 	Se permite acceso anónimo a consultas de productos
• 	Se mantiene la autenticación obligatoria para creación, edición y eliminación
Motivación:
Este ajuste permite que el frontend consuma productos sin requerir autenticación, lo cual es útil para catálogos públicos o vistas previas. Al mismo tiempo, se refuerza la seguridad en operaciones que modifican el estado del sistema.
Validación:
• 	Probado localmente con Bruno y logs de Spring Security
• 	Confirmado comportamiento esperado:  sin token,  con JWT válido
• 	No se alteró la estructura original del proyecto